### PR TITLE
move FFRaceable protocol to its own file and use protocol RaceTrack file

### DIFF
--- a/FastAndFurious.xcodeproj/project.pbxproj
+++ b/FastAndFurious.xcodeproj/project.pbxproj
@@ -53,11 +53,11 @@
 		D501AB2F1E5D1F4100CA073B /* FastAndFuriousUITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = FastAndFuriousUITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		D501AB331E5D1F4100CA073B /* FastAndFuriousUITests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = FastAndFuriousUITests.m; sourceTree = "<group>"; };
 		D501AB351E5D1F4100CA073B /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
-		D501AB411E5D200B00CA073B /* FFRaceable.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = FFRaceable.h; sourceTree = "<group>"; };
 		D501AB421E5D21BC00CA073B /* FFRacecar.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FFRacecar.h; sourceTree = "<group>"; };
 		D501AB431E5D21BC00CA073B /* FFRacecar.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FFRacecar.m; sourceTree = "<group>"; };
 		D501AB451E5D23F500CA073B /* FastAndFurious-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "FastAndFurious-Bridging-Header.h"; sourceTree = "<group>"; };
 		D501AB461E5D23F600CA073B /* RaceTrack.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RaceTrack.swift; sourceTree = "<group>"; };
+		DC5F7AEC1E5D63F90050A948 /* FFRaceable.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FFRaceable.h; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -112,7 +112,7 @@
 				D501AB121E5D1F4100CA073B /* AppDelegate.m */,
 				D501AB141E5D1F4100CA073B /* FFRaceTrackViewController.h */,
 				D501AB151E5D1F4100CA073B /* FFRaceTrackViewController.m */,
-				D501AB411E5D200B00CA073B /* FFRaceable.h */,
+				DC5F7AEC1E5D63F90050A948 /* FFRaceable.h */,
 				D501AB421E5D21BC00CA073B /* FFRacecar.h */,
 				D501AB431E5D21BC00CA073B /* FFRacecar.m */,
 				D501AB461E5D23F600CA073B /* RaceTrack.swift */,
@@ -542,6 +542,7 @@
 				D501AB3A1E5D1F4100CA073B /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
 		};
 		D501AB3B1E5D1F4100CA073B /* Build configuration list for PBXNativeTarget "FastAndFuriousTests" */ = {
 			isa = XCConfigurationList;
@@ -550,6 +551,7 @@
 				D501AB3D1E5D1F4100CA073B /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
 		};
 		D501AB3E1E5D1F4100CA073B /* Build configuration list for PBXNativeTarget "FastAndFuriousUITests" */ = {
 			isa = XCConfigurationList;
@@ -558,6 +560,7 @@
 				D501AB401E5D1F4100CA073B /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
 		};
 /* End XCConfigurationList section */
 	};

--- a/FastAndFurious/FFRaceable.h
+++ b/FastAndFurious/FFRaceable.h
@@ -1,1 +1,9 @@
+#import <Foundation/Foundation.h>
 
+@protocol FFRaceable <NSObject>
+
+@property (nonatomic, readonly) float topSpeed;
+@property (nonatomic, readonly) float durability;
+@property (nonatomic, readonly) NSString *racecarID;
+
+@end

--- a/FastAndFurious/FFRacecar.h
+++ b/FastAndFurious/FFRacecar.h
@@ -1,14 +1,8 @@
 #import <Foundation/Foundation.h>
-
-@protocol FFRaceable
-
-@property (nonatomic, readonly) float topSpeed;
-@property (nonatomic, readonly) float durability;
-@property (nonatomic, readonly) NSString *racecarID;
-
-@end
+#import "FFRaceable.h"
 
 @interface FFRacecar : NSObject <FFRaceable>
+
 
 - (instancetype)initWithTopSpeed:(float)topSpeed
                       durability:(float)durablility;

--- a/FastAndFurious/FastAndFurious-Bridging-Header.h
+++ b/FastAndFurious/FastAndFurious-Bridging-Header.h
@@ -2,5 +2,6 @@
 //  Use this file to import your target's public headers that you would like to expose to Swift.
 
 #import "FFRacecar.h"
+#import "FFRaceable.h"
 //
 

--- a/FastAndFurious/RaceTrack.swift
+++ b/FastAndFurious/RaceTrack.swift
@@ -4,7 +4,7 @@
 
 class RaceTrack: NSObject {
 
-    let raceCars: [FFRacecar]
+    let raceCars: [FFRaceable]
     weak var observer: RaceTrackObservable?
     fileprivate var timer: Timer?
 
@@ -35,7 +35,7 @@ class RaceTrack: NSObject {
         observer?.raceCarsDidMove(distancesForIdentifiers: distancesForIdentifiers)
     }
 
-    fileprivate func generateNewDistance(for car: FFRacecar) -> Float {
+    fileprivate func generateNewDistance(for car: FFRaceable) -> Float {
 
         enum VariabilityLevel: Float {
             case low = 0.9


### PR DESCRIPTION
I think the reason we couldn't access the `racecarID` property is because we didn't define the array to be of FFRaceable objects in the `RaceTrack.swift` file, now it works :)